### PR TITLE
Fixed normalization for translatable entities

### DIFF
--- a/Normalizer/ReferableNormalizer.php
+++ b/Normalizer/ReferableNormalizer.php
@@ -2,7 +2,7 @@
 
 namespace Pim\Bundle\CustomEntityBundle\Normalizer;
 
-use Pim\Bundle\CatalogBundle\Model\ReferableInterface;
+use Pim\Bundle\CustomEntityBundle\Entity\AbstractCustomEntity;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -48,6 +48,6 @@ class ReferableNormalizer implements NormalizerInterface
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof ReferableInterface && in_array($format, $this->allowedformats);
+        return $data instanceof AbstractCustomEntity && in_array($format, $this->allowedformats);
     }
 }

--- a/Resources/config/serializer.yml
+++ b/Resources/config/serializer.yml
@@ -8,8 +8,8 @@ services:
         arguments:
             - ['csv', 'flat']
         tags:
-            - { name: pim_versioning.serializer.normalizer, priority: 80 }
-            - { name: pim_serializer.normalizer, priority: 80 }
+            - { name: pim_versioning.serializer.normalizer, priority: 100 }
+            - { name: pim_serializer.normalizer, priority: 100 }
 
     pim_custom_entity.normalizer.mongodb_referable:
         class: %pim_custom_entity.normalizer.mongodb_referable.class%


### PR DESCRIPTION
TranslatableNormalizer from the PIM CE Transform Bundle took priority over ReferableNormalizer from this bundle, leading to wrong format export for attributes based on TranslatableCustomOption, and therefore breaking history